### PR TITLE
Fixing object schema

### DIFF
--- a/openAPI/catalogo-ssu_to_bo.yaml
+++ b/openAPI/catalogo-ssu_to_bo.yaml
@@ -199,9 +199,9 @@ components:
           type: string
           format: date
         max_gg_proc:          
-                title: numero di giorni limite a partire da start entro cui l'istanza deve concludersi
-                type: integer
-                format: int32
+          title: numero di giorni limite a partire da start entro cui l'istanza deve concludersi
+          type: integer
+          format: int32
         max_gg_admissibility:          
           title: numero di giorni limite a partire da start per la verifica di ammissibilità
           type: integer

--- a/openAPI/catalogo-ssu_to_bo.yaml
+++ b/openAPI/catalogo-ssu_to_bo.yaml
@@ -192,16 +192,16 @@ components:
       type: object
       required:
       - start
-      - end
+      - max_gg_proc
       properties:
-        start:          
+        start:
           title: data avvio dell'istanza
           type: string
           format: date
         max_gg_proc:          
-          title: numero di giorni limite a partire da start entro cui l'istanza deve concludersi
-          type: integer
-          format: int32
+                title: numero di giorni limite a partire da start entro cui l'istanza deve concludersi
+                type: integer
+                format: int32
         max_gg_admissibility:          
           title: numero di giorni limite a partire da start per la verifica di ammissibilità
           type: integer
@@ -222,7 +222,7 @@ components:
           title: numero di giorni limite a partire da start entro cui gli enti terzi possono richiedere conferenza di servizi sincrona
           type: integer
           format: int32
-        date_cdss:          
+        date_cdss:
           title: data evetuale conferenza di servizi sincrona
           type: string
           format: date

--- a/openAPI/catalogo-ssu_to_cu.yaml
+++ b/openAPI/catalogo-ssu_to_cu.yaml
@@ -145,40 +145,40 @@ components:
             type: object
             required:
             - start
-            - end
+            - max_gg_proc
             properties:
-                start:          
-                    title: data avvio dell'istanza
-                    type: string
-                    format: date
-                end:          
-                    title: data entro cui l'istanza deve concludersi
-                    type: string
-                    format: date
-                max_admissibility:          
-                    title: data limite verifica ammissibilità
-                    type: string
-                    format: date
-                max_integration_request:          
-                    title: data limite richiesta integrazione degli enti terzi
-                    type: string
-                    format: date
-                max_integration_response:          
-                    title: data limite integrazione del soggetto presentatore
-                    type: string
-                    format: date
-                max_conclusions_sending:          
-                    title: data limite inoltro conclusioni degli enti terzi
-                    type: string
-                    format: date
-                date_cdss:          
-                    title: data evetuale conferenza di servizi sincrona
-                    type: string
-                    format: date
-                max_cdss_request:          
-                    title: data entro cui gli enti terzi possono richiedere conferenza di servizi sincrona
-                    type: string
-                    format: date
+              start:
+                title: data avvio dell'istanza
+                type: string
+                format: date
+              max_gg_proc:          
+                title: numero di giorni limite a partire da start entro cui l'istanza deve concludersi
+                type: integer
+                format: int32
+              max_gg_admissibility:          
+                title: numero di giorni limite a partire da start per la verifica di ammissibilità
+                type: integer
+                format: int32
+              max_gg_int_req:          
+                title: numero di giorni limite a partire da start per la richiesta di integrazione degli enti terzi
+                type: integer
+                format: int32
+              max_gg_int_resp:          
+                title: numero di giorni limite a partire da start per integrazione del soggetto presentatore
+                type: integer
+                format: int32
+              max_gg_concl_send:          
+                title: numero di giorni limite a partire da start per inoltro delle conclusioni degli enti terzi
+                type: integer
+                format: int32
+              max_gg_cdss_req:          
+                title: numero di giorni limite a partire da start entro cui gli enti terzi possono richiedere conferenza di servizi sincrona
+                type: integer
+                format: int32
+              date_cdss:
+                title: data evetuale conferenza di servizi sincrona
+                type: string
+                format: date
             
         AdministrationSchema:
             description: Amministrazione compentente censita nel Catalogo SSU

--- a/openAPI/catalogo-ssu_to_et.yaml
+++ b/openAPI/catalogo-ssu_to_et.yaml
@@ -226,9 +226,9 @@ components:
       type: object
       required:
       - start
-      - end
+      - max_gg_proc
       properties:
-        start:          
+        start:
           title: data avvio dell'istanza
           type: string
           format: date
@@ -256,7 +256,7 @@ components:
           title: numero di giorni limite a partire da start entro cui gli enti terzi possono richiedere conferenza di servizi sincrona
           type: integer
           format: int32
-        date_cdss:          
+        date_cdss:
           title: data evetuale conferenza di servizi sincrona
           type: string
           format: date

--- a/openAPI/catalogo-ssu_to_fo.yaml
+++ b/openAPI/catalogo-ssu_to_fo.yaml
@@ -247,9 +247,9 @@ components:
       type: object
       required:
       - start
-      - end
+      - max_gg_proc
       properties:
-        start:          
+        start:
           title: data avvio dell'istanza
           type: string
           format: date
@@ -277,7 +277,7 @@ components:
           title: numero di giorni limite a partire da start entro cui gli enti terzi possono richiedere conferenza di servizi sincrona
           type: integer
           format: int32
-        date_cdss:          
+        date_cdss:
           title: data evetuale conferenza di servizi sincrona
           type: string
           format: date

--- a/openAPI/catalogo-ssu_to_ri.yaml
+++ b/openAPI/catalogo-ssu_to_ri.yaml
@@ -146,40 +146,40 @@ components:
             type: object
             required:
             - start
-            - end
+            - max_gg_proc
             properties:
-                start:          
-                    title: data avvio dell'istanza
-                    type: string
-                    format: date
-                end:          
-                    title: data entro cui l'istanza deve concludersi
-                    type: string
-                    format: date
-                max_admissibility:          
-                    title: data limite verifica ammissibilità
-                    type: string
-                    format: date
-                max_integration_request:          
-                    title: data limite richiesta integrazione degli enti terzi
-                    type: string
-                    format: date
-                max_integration_response:          
-                    title: data limite integrazione del soggetto presentatore
-                    type: string
-                    format: date
-                max_conclusions_sending:          
-                    title: data limite inoltro conclusioni degli enti terzi
-                    type: string
-                    format: date
-                date_cdss:          
-                    title: data evetuale conferenza di servizi sincrona
-                    type: string
-                    format: date
-                max_cdss_request:          
-                    title: data entro cui gli enti terzi possono richiedere conferenza di servizi sincrona
-                    type: string
-                    format: date
+              start:
+                title: data avvio dell'istanza
+                type: string
+                format: date
+              max_gg_proc:          
+                title: numero di giorni limite a partire da start entro cui l'istanza deve concludersi
+                type: integer
+                format: int32
+              max_gg_admissibility:          
+                title: numero di giorni limite a partire da start per la verifica di ammissibilità
+                type: integer
+                format: int32
+              max_gg_int_req:          
+                title: numero di giorni limite a partire da start per la richiesta di integrazione degli enti terzi
+                type: integer
+                format: int32
+              max_gg_int_resp:          
+                title: numero di giorni limite a partire da start per integrazione del soggetto presentatore
+                type: integer
+                format: int32
+              max_gg_concl_send:          
+                title: numero di giorni limite a partire da start per inoltro delle conclusioni degli enti terzi
+                type: integer
+                format: int32
+              max_gg_cdss_req:          
+                title: numero di giorni limite a partire da start entro cui gli enti terzi possono richiedere conferenza di servizi sincrona
+                type: integer
+                format: int32
+              date_cdss:
+                title: data evetuale conferenza di servizi sincrona
+                type: string
+                format: date
 
         AdministrationSchema:
             description: Amministrazione compentente censita nel Catalogo SSU


### PR DESCRIPTION
A seguito di un'analisi sulle OpenAPI, abbiamo modificato lo schema del 'Times' poiché risultava disallineato con lo schema presente nel file times-schema.yaml (https://github.com/AgID/specifiche-tecniche-DPR-160-2010/blob/mantaince001/json-schema/times-schema.yaml).
Possiamo considerarla un'integrazione della issue #12 
(https://github.com/AgID/specifiche-tecniche-DPR-160-2010/issues/12).