### PR TITLE
Update catalogo-ssu_to_et.yaml

### DIFF
--- a/openAPI/catalogo-ssu_to_et.yaml
+++ b/openAPI/catalogo-ssu_to_et.yaml
@@ -278,7 +278,7 @@ components:
       type: object
       description: risposta AdministrationGhost
       required:
-        - type
+        - cui_uuid
       properties:
         cui_uuid:
           title: tipo messaggio


### PR DESCRIPTION
È stato rimosso type dall’elenco dei campi required, in quanto non presente tra le properties dello schema.