### PR TITLE
Update et_to_et.yaml

### DIFF
--- a/openAPI/et_to_et.yaml
+++ b/openAPI/et_to_et.yaml
@@ -31,7 +31,6 @@ paths:
         "200": { $ref: "#/components/responses/OKRequest" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
-        "428": { $ref: "#/components/responses/PreconditionRequired" }
         "500": { $ref: "#/components/responses/ServerError" }
         "503": { $ref: "#/components/responses/ServiceUnavailable" }
       security:
@@ -105,7 +104,6 @@ paths:
         "200": { $ref: "#/components/responses/OKRequest" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
-        "428": { $ref: "#/components/responses/PreconditionRequired" }
         "500": { $ref: "#/components/responses/ServerError" }
         "503": { $ref: "#/components/responses/ServiceUnavailable" }
       security:
@@ -130,7 +128,6 @@ paths:
         "200": { $ref: "#/components/responses/OKRequest" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
-        "428": { $ref: "#/components/responses/PreconditionRequired" }
         "500": { $ref: "#/components/responses/ServerError" }
         "503": { $ref: "#/components/responses/ServiceUnavailable" }
       security:
@@ -155,7 +152,6 @@ paths:
         "200": { $ref: "#/components/responses/OKRequest" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
-        "428": { $ref: "#/components/responses/PreconditionRequired" }
         "500": { $ref: "#/components/responses/ServerError" }
         "503": { $ref: "#/components/responses/ServiceUnavailable" }
       security:
@@ -180,7 +176,6 @@ paths:
         "200": { $ref: "#/components/responses/OKRequest" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
-        "428": { $ref: "#/components/responses/PreconditionRequired" }
         "500": { $ref: "#/components/responses/ServerError" }
         "503": { $ref: "#/components/responses/ServiceUnavailable" }
       security:
@@ -221,7 +216,6 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { $ref: "#/components/responses/Conflict" }
-        "428": { $ref: "#/components/responses/PreconditionRequired" }
         "500": { $ref: "#/components/responses/ServerError" }
         "503": { $ref: "#/components/responses/ServiceUnavailable" }
       security:


### PR DESCRIPTION
Rimosso l'errore HTTP 428 (Precondition Required) dalle operation per cui non è applicabile all'interno dell'OpenAPI et_to_et; la risposta 428 è ora prevista esclusivamente per l'endpoint /instance/{cui_uuid}/document/{resource_id}.